### PR TITLE
Define gray-streams for clasp, also allow testing for clasp

### DIFF
--- a/chipz.asd
+++ b/chipz.asd
@@ -8,7 +8,7 @@
 (defclass css-file (doc-file) ((type :initform "css")))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  #+(or sbcl lispworks openmcl cmu allegro clisp ecl genera)
+  #+(or sbcl lispworks openmcl cmu allegro clisp ecl genera clasp)
   (pushnew 'chipz-system:gray-streams cl:*features*))
 
 (asdf:defsystem :chipz

--- a/stream.lisp
+++ b/stream.lisp
@@ -31,6 +31,7 @@
      #+allegro 'excl:fundamental-binary-input-stream
      #+clisp 'gray:fundamental-binary-input-stream
      #+ecl 'gray:fundamental-binary-input-stream
+     #+clasp 'gray:fundamental-binary-input-stream
      #+genera 'gray-streams:fundamental-binary-input-stream)
 
   (defvar *stream-read-byte-function*
@@ -41,6 +42,7 @@
      #+allegro 'excl:stream-read-byte
      #+clisp 'gray:stream-read-byte
      #+ecl 'gray:stream-read-byte
+     #+clasp 'gray:stream-read-byte
      #+genera 'gray-streams:stream-read-byte)
 
   (defvar *stream-read-sequence-function*
@@ -51,6 +53,7 @@
      #+allegro 'excl:stream-read-sequence
      #+clisp 'gray:stream-read-byte-sequence
      #+ecl 'gray:stream-read-sequence
+     #+clasp 'gray:stream-read-sequence
      #+genera 'gray-streams:stream-read-sequence)
 ) ; EVAL-WHEN
 
@@ -65,7 +68,7 @@
                 (let ((end (or end (length seq))))
                   ,@body)))))
 
-    #+(or cmu sbcl allegro ecl genera)
+    #+(or cmu sbcl allegro ecl clasp genera)
     `(defmethod #.*stream-read-sequence-function* ((stream ,specializer) seq &optional (start 0) end)
        ,definition)
 

--- a/tests.lisp
+++ b/tests.lisp
@@ -201,7 +201,13 @@
   #+ecl
   (ext:run-program
    executable args :output output-file :if-output-exists :supersede)
-  #-(or lispworks sbcl openmcl cmu clisp ecl)
+  #+clasp
+  (ext:system (concatenate 'string executable " "
+                           (with-output-to-string (stream)
+                             (dolist (x args)
+                               (princ x stream)(princ " " stream)))
+                           " >" (namestring output-file)))
+  #-(or lispworks sbcl openmcl cmu clisp ecl clasp)
   (error "run-external is not supported for this lisp implementation"))
 
 (defun compress-test-files (&optional (test-files-dir *default-test-files-dir*))


### PR DESCRIPTION
* define `chipz-system:gray-streams` for clasp (basically like ecl)
* define simplified `ext:run-program` for clasp testing