### PR TITLE
Call bzip2 state machine functions in a loop

### DIFF
--- a/bzip2.lisp
+++ b/bzip2.lisp
@@ -942,7 +942,7 @@
              )
       (unless (bzip2-state-state state)
         (setf (bzip2-state-state state) #'bzip2-header))
-      (funcall (the function (bzip2-state-state state)) state))))
+      (loop (funcall (the function (bzip2-state-state state)) state)))))
 
 (defun %bzip2-decompress (state input output &key (input-start 0) input-end
                           (output-start 0) output-end)


### PR DESCRIPTION
This is required for implementations like CCL that don't rely on tail call elimination. The Deflate decompressor already does this but the bzip2 one didn't.