### PR TITLE
Account for case where exactly 900000 elements are in a bzip2 block

### DIFF
--- a/bzip2.lisp
+++ b/bzip2.lisp
@@ -123,7 +123,7 @@
   (group-position 0 :type fixnum)
   (lval 0 :type fixnum)
   (nblockMAX 0 :type (integer 0 900000))
-  (nblock 0 :type (integer 0 (900000)))
+  (nblock 0 :type (integer 0 900000))
   (es 0 :type fixnum)
   (N 0 :type fixnum)
   (curr 0 :type (integer 0 20))
@@ -212,7 +212,7 @@
        (declare (type (unsigned-byte 32) calculated-block-crc))
        (declare (type (integer 0 260) out-len))
        (declare (type (unsigned-byte 8) k0 k1))
-       (declare (type (integer 0 900000) n-blocks-used nblockpp))
+       (declare (type (integer 0 900001) n-blocks-used nblockpp))
        (declare (type (unsigned-byte 32) t-position))
        (macrolet ((get-fast ()
                     `(prog2


### PR DESCRIPTION
The `incf` at the end of `bzip2-finish-rle-sequence` can push `nblock` to 900000 in violation of its type declaration. This also affects two later variables. A file that triggers the issue under SBCL can be found [here](https://semelz.de/files/xorg-server-1.20.11.tar.bz2).

I went with the most straightforward way to correct this; it may be possible to avoid redefining the struct in an incompatible way, but I'm not _that_ familiar with the bzip2 source code.