### PR TITLE
Handle expansions across the literal/length-distance boundary

### DIFF
--- a/inflate-state.lisp
+++ b/inflate-state.lisp
@@ -20,7 +20,7 @@
   (n-distance-codes 0)
   (n-codes 0)
   (n-values-read 0)
-  (code-lengths (make-array 288) :type (simple-vector 288))
+  (code-lengths (make-array 320) :type (simple-vector 320))
   ;; sliding window
   (window (make-array 32768 :element-type '(unsigned-byte 8))
           :type sliding-window)

--- a/inflate.lisp
+++ b/inflate.lisp
@@ -204,9 +204,7 @@ the input and the number of bytes written to the output."
                                (fill lengths sym :start (inflate-state-n-values-read state)
                                      :end (+ (inflate-state-n-values-read state) len))
                                (incf (inflate-state-n-values-read state) len)))))
-                     finally (progn
-                               (assert (= n-values (inflate-state-n-values-read state)))
-                               (return (construct-huffman-decode-table lengths n-values)))))
+                     finally (assert (= n-values (inflate-state-n-values-read state)))))
 
              ;; Basic starter functions.
              (done (state)
@@ -303,21 +301,20 @@ the input and the number of bytes written to the output."
                      (construct-huffman-decode-table (inflate-state-code-lengths state)
                                                      +max-n-code-lengths+)
                      (inflate-state-n-values-read state) 0)
-               (transition-to dynamic-literal/length-table))
+               (transition-to dynamic-literal/length+distance-tables))
 
-             (dynamic-literal/length-table (state)
+             (dynamic-literal/length+distance-tables (state)
                (declare (type inflate-state state))
+               (read-dynamic-table state (inflate-state-codes-table state)
+                                   (+ (inflate-state-n-length-codes state)
+                                      (inflate-state-n-distance-codes state)))
                (setf (inflate-state-literal/length-table state)
-                     (read-dynamic-table state (inflate-state-codes-table state)
-                                         (inflate-state-n-length-codes state))
-                     (inflate-state-n-values-read state) 0)
-               (transition-to dynamic-distance-table))
-
-             (dynamic-distance-table (state)
-               (declare (type inflate-state state))
+                     (construct-huffman-decode-table (inflate-state-code-lengths state)
+                                                     (inflate-state-n-length-codes state)))
                (setf (inflate-state-distance-table state)
-                     (read-dynamic-table state (inflate-state-codes-table state)
-                                         (inflate-state-n-distance-codes state)))
+                     (construct-huffman-decode-table (inflate-state-code-lengths state)
+                                                     (inflate-state-n-distance-codes state)
+                                                     (inflate-state-n-length-codes state)))
                (transition-to literal/length))
 
 ;;; normal operation on compressed blocks

--- a/types-and-tables.lisp
+++ b/types-and-tables.lisp
@@ -58,8 +58,9 @@
 
 ;;; decode table construction
 
-(defun construct-huffman-decode-table (code-lengths &optional n-syms)
+(defun construct-huffman-decode-table (code-lengths &optional n-syms start)
   (let* ((n-syms (or n-syms (length code-lengths)))
+         (start (or start 0))
          (min-code-length +max-code-length+)
          (max-code-length 0)
          (counts (make-array +max-code-length+ :initial-element 0
@@ -69,7 +70,7 @@
          (symbols (make-array n-syms :initial-element 0 :element-type 'fixnum)))
     (declare (type (simple-array (unsigned-byte 16) (*)) counts)
              (type (simple-array fixnum (*)) symbols))
-    (dotimes (i n-syms)
+    (loop for i from start below (+ start n-syms) do
       (let ((c (aref code-lengths i)))
         (setf min-code-length (min min-code-length c))
         (setf max-code-length (max max-code-length c))
@@ -78,7 +79,7 @@
     (loop for i from 1 below +deflate-max-bits+
           do (setf (aref offsets (1+ i)) (+ (aref offsets i) (aref counts i))))
     (dotimes (i n-syms (make-hdt counts offsets symbols max-code-length))
-      (let ((l (aref code-lengths i)))
+      (let ((l (aref code-lengths (+ start i))))
         (unless (zerop l)
           (setf (aref symbols (aref offsets l)) i)
           (incf (aref offsets l)))))))


### PR DESCRIPTION
These are explicitly allowed by Deflate, see end of [§3.2.7](https://www.rfc-editor.org/rfc/rfc1951#page-14):

> The code length repeat codes can cross from HLIT + 257 to the HDIST + 1 code lengths.  In other words, all code lengths form a single sequence of HLIT + HDIST + 258 values.

A raw Deflate example file that uses this is `#(237 253 181 181 109 219 182 109 219 250 111 117 140 158 196 104 136)`, which decodes to `#(255)`.