### PR TITLE
Check for out of bounds accesses and missing Huffman codes

### DIFF
--- a/conditions.lisp
+++ b/conditions.lisp
@@ -78,6 +78,41 @@ consistency check."))
   (:documentation "Signaled when a stored block's length does not pass
 the consistency check."))
 
+(define-condition code-lengths-bounds-error (inflate-error)
+  ()
+  (:report (lambda (condition stream)
+             (declare (ignore condition))
+             (format stream "Code lengths expand out of bounds")))
+  (:documentation "Signaled when the code length section of a dynamic block would produce more
+code lengths than declared."))
+
+(define-condition code-lengths-start-with-repetition-error (inflate-error)
+  ()
+  (:report (lambda (condition stream)
+             (declare (ignore condition))
+             (format stream "Code lengths start with a repetition")))
+  (:documentation "Signaled when the code length section of a dynamic block begins with \"repeat
+last code\"."))
+
+(define-condition unassigned-huffman-code-error (inflate-error)
+  ()
+  (:report (lambda (condition stream)
+             (declare (ignore condition))
+             (format stream "Unassigned Huffman code")))
+  (:documentation "Signaled when an unassigned Huffman code is referenced."))
+
+(define-condition illegal-length-code-error (inflate-error)
+  ((code :initarg :code :reader illegal-code))
+  (:report (lambda (condition stream)
+             (format stream "Illegal length code: ~d" (illegal-code condition))))
+  (:documentation "Signaled when the illegal length codes 286 or 287 are used."))
+
+(define-condition illegal-distance-code-error (inflate-error)
+  ((code :initarg :code :reader illegal-code))
+  (:report (lambda (condition stream)
+             (format stream "Illegal distance code: ~d" (illegal-code condition))))
+  (:documentation "Signaled when the illegal distance codes 30 or 31 are used."))
+
 
 ;;; Errors related to bzip2
 

--- a/inflate.lisp
+++ b/inflate.lisp
@@ -196,12 +196,18 @@ the input and the number of bytes written to the output."
                              (let ((len 0) (sym 0))
                                (cond
                                  ((= value 16)
+                                  (when (zerop (inflate-state-n-values-read state))
+                                    (error 'decompression-error
+                                           :format-control "Code lengths start with a repetition"))
                                   (setf sym (aref lengths (1- (inflate-state-n-values-read state))))
                                   (setf len (+ 3 (read-bits 2 state))))
                                  ((= value 17)
                                   (setf len (+ 3 (read-bits 3 state))))
                                  ((= value 18)
                                   (setf len (+ 11 (read-bits 7 state)))))
+                               (when (< n-values (+ (inflate-state-n-values-read state) len))
+                                 (error 'decompression-error
+                                        :format-control "Code lengths continue beyond bounds"))
                                (fill lengths sym :start (inflate-state-n-values-read state)
                                      :end (+ (inflate-state-n-values-read state) len))
                                (incf (inflate-state-n-values-read state) len)))))

--- a/inflate.lisp
+++ b/inflate.lisp
@@ -163,7 +163,8 @@ the input and the number of bytes written to the output."
                       (len 1 (1+ len))
                       (first 0 (probably-the-fixnum (ash first 1)))
                       (code 0 (probably-the-fixnum (ash code 1))))
-                     ((>= len +max-code-length+) nil)
+                     ((>= len +max-code-length+)
+                      (error 'decompression-error :format-control "Invalid Huffman code"))
                    (declare (type (and fixnum (integer 0 *)) first code))
                    ;; We would normally do this with READ-BITS, but DECODE-VALUE
                    ;; is a hotspot in profiles along with this would-be call to
@@ -331,6 +332,10 @@ the input and the number of bytes written to the output."
                    ((< value 256)
                     (setf (inflate-state-length state) value)
                     (transition-to literal))
+                   ((> value 285)
+                    (error 'decompression-error
+                           :format-control "Invalid length code: ~d"
+                           :format-arguments (list value)))
                    ((> value 256)
                     (setf (inflate-state-length-code state) (- value 257))
                     (transition-to length-code))
@@ -360,6 +365,10 @@ the input and the number of bytes written to the output."
                (declare (type inflate-state state))
                (let ((value (decode-value (inflate-state-distance-table state)
                                           state)))
+                 (when (> value 29)
+                   (error 'decompression-error
+                          :format-control "Invalid distance code: ~d"
+                          :format-arguments (list value)))
                  (setf (inflate-state-distance state) value)
                  (transition-to distance-extra)))
 

--- a/inflate.lisp
+++ b/inflate.lisp
@@ -164,7 +164,7 @@ the input and the number of bytes written to the output."
                       (first 0 (probably-the-fixnum (ash first 1)))
                       (code 0 (probably-the-fixnum (ash code 1))))
                      ((>= len +max-code-length+)
-                      (error 'decompression-error :format-control "Invalid Huffman code"))
+                      (error 'unassigned-huffman-code-error))
                    (declare (type (and fixnum (integer 0 *)) first code))
                    ;; We would normally do this with READ-BITS, but DECODE-VALUE
                    ;; is a hotspot in profiles along with this would-be call to
@@ -197,8 +197,7 @@ the input and the number of bytes written to the output."
                                (cond
                                  ((= value 16)
                                   (when (zerop (inflate-state-n-values-read state))
-                                    (error 'decompression-error
-                                           :format-control "Code lengths start with a repetition"))
+                                    (error 'code-lengths-start-with-repetition-error))
                                   (setf sym (aref lengths (1- (inflate-state-n-values-read state))))
                                   (setf len (+ 3 (read-bits 2 state))))
                                  ((= value 17)
@@ -206,8 +205,7 @@ the input and the number of bytes written to the output."
                                  ((= value 18)
                                   (setf len (+ 11 (read-bits 7 state)))))
                                (when (< n-values (+ (inflate-state-n-values-read state) len))
-                                 (error 'decompression-error
-                                        :format-control "Code lengths continue beyond bounds"))
+                                 (error 'code-lengths-bounds-error))
                                (fill lengths sym :start (inflate-state-n-values-read state)
                                      :end (+ (inflate-state-n-values-read state) len))
                                (incf (inflate-state-n-values-read state) len)))))
@@ -339,9 +337,7 @@ the input and the number of bytes written to the output."
                     (setf (inflate-state-length state) value)
                     (transition-to literal))
                    ((> value 285)
-                    (error 'decompression-error
-                           :format-control "Invalid length code: ~d"
-                           :format-arguments (list value)))
+                    (error 'illegal-length-code-error :code value))
                    ((> value 256)
                     (setf (inflate-state-length-code state) (- value 257))
                     (transition-to length-code))
@@ -372,9 +368,7 @@ the input and the number of bytes written to the output."
                (let ((value (decode-value (inflate-state-distance-table state)
                                           state)))
                  (when (> value 29)
-                   (error 'decompression-error
-                          :format-control "Invalid distance code: ~d"
-                          :format-arguments (list value)))
+                   (error 'illegal-distance-code-error :code value))
                  (setf (inflate-state-distance state) value)
                  (transition-to distance-extra)))
 

--- a/types-and-tables.lisp
+++ b/types-and-tables.lisp
@@ -93,7 +93,7 @@
        '(143 255 279 287)))             ; end values
 
 (defparameter *fixed-block-distance-lengths*
-  (list (make-crd 5 0 29)))
+  (list (make-crd 5 0 31)))
 
 (defun code-n-values (c)
   (1+ (- (code-end-value c) (code-start-value c))))


### PR DESCRIPTION
The patch is pretty self-explanatory, but I'm not sure what to do about error types here. In my own library I similarly just used a generic type with a message, but chipz already provides detailed error types for everything else in the Deflate decoder and even a restart to work around a specific bug, so maybe new error types would be more sensible. In that case one might have to adjust the definition of the fixed Huffman code though since it'll run into the path for unassigned codes right now.

Raw Deflate test data that exercises the various edge cases can be found below. Apologies for some of the lengths; I took shortcuts during generation.

- Code lengths start with "repeat last code": `#(237 253 181 181 109 219 182 109 219 130 255 62 199 232 73 140 134 8)`
- Code lengths that go beyond bounds: `#(237 253 181 181 109 219 182 109 219 250 111 117 140 158 196 232 136)`
- A dynamic block that attempts to use an unassigned code: `#(237 253 1 144 36 73 146 36 73 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
  0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
  0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
  0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0
  0 0 0 168 170 170 170 170 170 170 170 170 170 170 170 170 170 138 20 0 1)`
- A fixed block that uses the invalid length code 286: `#(99 28 3 0)`
- A fixed block that uses the invalid distance code 30 (triggers the path for unassigned codes in chipz): `#(99 4 62 0 0 0 0)`
- A dynamic block that uses the invalid distance code 30: `#(253 255 1 144 36 73 146 36 73 70 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68
  68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68
  68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68 68
  68 68 68 68 100 102 102 102 102 102 102 102 102 102 102 102 102 102 102 102
  102 102 102 102 102 102 102 102 102 102 102 102 102 102 102 102 102 102 102
  102 102 102 102 102 102 102 102 102 102 102 102 102 102 102 102 102 102 102
  102 102 186 187 187 187 187 187 187 187 187 187 187 187 71 68 68 68 168 170
  170 170 170 170 170 170 170 170 170 170 170 170 170 170 50 50 49 3 31 0)`